### PR TITLE
OnehotEncoding

### DIFF
--- a/train/transforms/categorical_data.py
+++ b/train/transforms/categorical_data.py
@@ -1,0 +1,26 @@
+from pyspark.ml.feature import OneHotEncoder, StringIndexer
+
+def handle_categorical_data(df, categorical_columns):
+    """
+    Xử lý dữ liệu phân loại bằng cách sử dụng One-hot encoding.
+
+    Args:
+        df: PySpark DataFrame.
+        categorical_columns: Danh sách các cột phân loại cần xử lý.
+
+    Returns:
+        PySpark DataFrame với các cột phân loại đã được mã hóa.
+    """
+
+    for categorical_col in categorical_columns:
+        # Tạo StringIndexer để chuyển đổi các giá trị chuỗi thành chỉ mục số
+        stringIndexer = StringIndexer(inputCol=categorical_col, outputCol=categorical_col + "_index")
+
+        # Tạo OneHotEncoder để chuyển đổi chỉ mục số thành vectơ 
+        encoder = OneHotEncoder(inputCols=[stringIndexer.getOutputCol()], outputCols=[categorical_col + "_encoded"])
+
+        # Khớp và chuyển đổi DataFrame
+        df = stringIndexer.fit(df).transform(df)
+        df = encoder.fit(df).transform(df)
+
+    return df


### PR DESCRIPTION
Đoạn code này thực hiện one-hot encoding cho các cột phân loại trong … DataFrame PySpark.

Đầu tiên, nó sử dụng StringIndexer để chuyển đổi các giá trị chuỗi thành chỉ mục số. Sau đó, OneHotEncoder được sử dụng để biến đổi các chỉ mục số này thành vectơ one-hot. Kết quả là DataFrame được cập nhật với các cột mới biểu diễn dữ liệu phân loại dưới dạng số, sẵn sàng cho các thuật toán Machine